### PR TITLE
2.0

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,5 +4,5 @@ parameters:
 services:
     flosch.stripe.client:
         class: "%flosch.stripe.client.class%"
-        arguments: ["%stripe_api_key%"]
+        arguments: ["%flosch_stripe.stripe_api_key%"]
         lazy: true

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "symfony/framework-bundle": "~3.0|~4.0",
+        "symfony/framework-bundle": "~3.0 || ~4.0",
         "stripe/stripe-php": "~3.23",
         "ocramius/proxy-manager": "~1.0.2 || ^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~4.0",
+        "symfony/framework-bundle": "~3.0|~4.0",
         "stripe/stripe-php": "~3.23",
         "ocramius/proxy-manager": "~1.0.2 || ^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~3.0",
+        "symfony/symfony": "~3.0 || ~4.0",
         "stripe/stripe-php": "~3.23",
         "ocramius/proxy-manager": "~1.0.2 || ^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
         }
     ],
     "require": {
-        "symfony/symfony": "~3.0 || ~4.0",
+        "symfony/symfony": "~4.0",
         "stripe/stripe-php": "~3.23",
         "ocramius/proxy-manager": "~1.0.2 || ^2.0"
     },


### PR DESCRIPTION
Hi again,

created this 2.0 branch with a 2.0 tag. I don't really know if I did correctly.

I just modified in the code : 
- the composer with 3.0 || 4.0
- the argument of the client from "stripe_api_key" to "flosch_stripe.stripe_api_key". The parameters.yml file does not exists anymore.

With this solution, you still have to write to a config file : 


flosch_stripe:
    stripe_api_key: "STRIPE_API_KEY"


The best would be to write a composer recipe (the new way of doing) which would write the config file when updating composer. But I did not found enough documentation on web to do it so far.

Theses modifications work for me on my environnement, at lest for creating charges/updating charges/customers.