### PR TITLE
Add FQCN alias for StripeClient

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -6,3 +6,4 @@ services:
         class: "%flosch.stripe.client.class%"
         arguments: ["%flosch_stripe.stripe_api_key%"]
         lazy: true
+    Flosch\Bundle\StripeBundle\Stripe\StripeClient: '@flosch.stripe.client'


### PR DESCRIPTION
Alias the `StripeClient` fully-qualified class name to the existing service configuration. Helps with auto-wiring. 😄